### PR TITLE
BitHeapCompressor code update

### DIFF
--- a/src/main/scala/Chainsaw/ChainsawBaseGenerator.scala
+++ b/src/main/scala/Chainsaw/ChainsawBaseGenerator.scala
@@ -143,9 +143,7 @@ trait ChainsawBaseGenerator {
 
   def cloneOutput = Vec(outputTypes.map(_.apply()))
 
-  def ffioUtil = VivadoUtil(ff =
-    inputTypes.map(_.bitWidth).sum + outputTypes.map(_.bitWidth).sum
-  )
+  def ffIoUtil = VivadoUtil(ff = inputTypes.map(_.bitWidth).sum + outputTypes.map(_.bitWidth).sum)
 }
 
 trait Dynamic {
@@ -216,10 +214,7 @@ trait ChainsawOperatorGenerator extends ChainsawBaseGenerator with Operator {
   override def randomTestCase = TestCase(randomDataVector)
 }
 
-trait ChainsawDynamicOperatorGenerator
-    extends ChainsawBaseGenerator
-    with Operator
-    with Dynamic {
+trait ChainsawDynamicOperatorGenerator extends ChainsawBaseGenerator with Operator with Dynamic {
 
   override def resetCycle = 0
 
@@ -241,6 +236,15 @@ trait ChainsawFrameGenerator extends ChainsawBaseGenerator with Frame {
   def inputFrameFormat: FrameFormat
 
   def outputFrameFormat: FrameFormat
+
+  require(
+    inputFrameFormat.portSize == inPortWidth,
+    s"Frame inPort size = ${inputFrameFormat.portSize}, actual inPort size = $inPortWidth"
+  )
+  require(
+    outputFrameFormat.portSize == outPortWidth,
+    s"Frame outPort size = ${outputFrameFormat.portSize}, actual outPort size = $outPortWidth"
+  )
 
   override def inputFrameFormat(control: Seq[BigDecimal]) = inputFrameFormat
 
@@ -272,10 +276,16 @@ trait ChainsawFrameGenerator extends ChainsawBaseGenerator with Frame {
   override def randomTestCase = TestCase(randomInputFrame)
 }
 
-trait ChainsawDynamicFrameGenerator
-    extends ChainsawBaseGenerator
-    with Frame
-    with Dynamic {
+trait ChainsawDynamicFrameGenerator extends ChainsawBaseGenerator with Frame with Dynamic {
+
+  require(
+    inputFrameFormat(randomControlVector).portSize == inPortWidth,
+    s"Frame inPort size = ${inputFrameFormat(randomControlVector).portSize}, actual inPort size = $inPortWidth"
+  )
+  require(
+    outputFrameFormat(randomControlVector).portSize == outPortWidth,
+    s"Frame outPort size = ${outputFrameFormat(randomControlVector).portSize}, actual outPort size = $outPortWidth"
+  )
 
   override def implH: ChainsawDynamicFrameModule
 
@@ -296,9 +306,7 @@ trait ChainsawDynamicFrameGenerator
   }
 }
 
-trait ChainsawInfiniteGenerator
-    extends ChainsawBaseGenerator
-    with SemiInfinite {
+trait ChainsawInfiniteGenerator extends ChainsawBaseGenerator with SemiInfinite {
 
   override def implH: ChainsawInfiniteModule
 
@@ -317,10 +325,7 @@ trait ChainsawInfiniteGenerator
   )
 }
 
-trait ChainsawDynamicInfiniteGenerator
-    extends ChainsawBaseGenerator
-    with SemiInfinite
-    with Dynamic {
+trait ChainsawDynamicInfiniteGenerator extends ChainsawBaseGenerator with SemiInfinite with Dynamic {
 
   override def implH: ChainsawDynamicInfiniteModule
 

--- a/src/main/scala/Chainsaw/Enums.scala
+++ b/src/main/scala/Chainsaw/Enums.scala
@@ -110,7 +110,10 @@ object IMPL extends EdaFlowType
 
 sealed trait CompressionStrategy extends ChainsawEnum
 object ReFirst extends CompressionStrategy // ReductionEfficiency First
-object HrFirst extends CompressionStrategy // HeightReduction First
+object HrFirst extends CompressionStrategy // HeightReduction(Latency) First
+object BrFirst extends CompressionStrategy // BitReduction First
+object RrFirst extends CompressionStrategy // ReductionRatio First
+object MinCost extends CompressionStrategy // Cost First
 
 sealed trait UtilRequirementStrategy extends ChainsawEnum
 object DefaultRequirement

--- a/src/main/scala/Chainsaw/NumericType.scala
+++ b/src/main/scala/Chainsaw/NumericType.scala
@@ -16,8 +16,7 @@ class NumericType(val maxRaw: BigInt, val minRaw: BigInt, val exp: Int) {
 
   val afixType = HardType(new AFix(maxRaw, minRaw, exp))
 
-  /** -------- get core attributes from AFix in virtual global data, to assure
-    * the consistency with SpinalHDL
+  /** -------- get core attributes from AFix in virtual global data, to assure the consistency with SpinalHDL
     * --------
     */
 
@@ -60,9 +59,10 @@ class NumericType(val maxRaw: BigInt, val minRaw: BigInt, val exp: Int) {
       constant >= ret.minValue,
       s"Literal $constant is too negative to be assigned in this $this"
     )
-    val intValue =
+    val intValue = {
       if (constant >= 0.0) (constant / step).toBigInt()
       else (constant / step).toBigInt().toBitValue(bitWidth).to2sComplement
+    }
     ret.raw := intValue
     ret
   }

--- a/src/main/scala/Chainsaw/arithmetic/bitheap/BitHeapSolver.scala
+++ b/src/main/scala/Chainsaw/arithmetic/bitheap/BitHeapSolver.scala
@@ -6,10 +6,66 @@ import Chainsaw.arithmetic._
 
 import scala.math._
 import scala.collection.mutable.ArrayBuffer
+import scala.collection._
 
 abstract class BitHeapSolver {
 
   def solverName = className(this)
+
+  // for solver logger
+  private var solveStageIndex = 1
+
+  // for strategy to get next time heap
+  var nextTimeHeap: Option[BitHeap[BigInt]] = None
+  var nextHeapCarry: mutable.Map[Int, Int]  = mutable.Map[Int, Int]()
+
+  // for save row adder search time
+  val searchThreshold = 0.2
+
+  // infer pipeline related
+  var inferPipelineMode = false
+
+  var startInferPipeline = false
+
+  var headFlipPipelineGap = 0
+
+  var tailFlipPipelineGap = 1
+
+  var pipelineState = true
+
+  private var recordHeadGap = headFlipPipelineGap
+  private var recordTailGap = tailFlipPipelineGap
+
+  def refreshPipelineState(bitHeap: BitHeap[BigInt]): Boolean = {
+    (bitHeap.reachLastStage, inferPipelineMode && startInferPipeline) match {
+      case (true, true) =>
+        if (recordTailGap == 1) {
+          pipelineState = !pipelineState
+          recordTailGap = tailFlipPipelineGap
+        } else {
+          recordTailGap -= 1
+        }
+      case (false, true) =>
+        if (recordHeadGap == 1) {
+          pipelineState = !pipelineState
+          recordHeadGap = headFlipPipelineGap
+        } else {
+          recordHeadGap -= 1
+        }
+      case _ =>
+    }
+    pipelineState
+  }
+
+  // for Solver Reuse
+  def absorbMetaInfosFrom(solver: BitHeapSolver): BitHeapSolver = {
+    inferPipelineMode   = solver.inferPipelineMode
+    startInferPipeline  = solver.startInferPipeline
+    headFlipPipelineGap = solver.headFlipPipelineGap
+    tailFlipPipelineGap = solver.tailFlipPipelineGap
+    pipelineState       = solver.pipelineState
+    this
+  }
 
   /** core method which must be kept
     */
@@ -17,14 +73,16 @@ abstract class BitHeapSolver {
 
     bitHeapGroup.absorbConstant()
 
-    val timeAndHeaps: Map[Int, BitHeap[BigInt]] = bitHeapGroup.bitHeaps.groupBy(_.time).map(pair => pair._1 -> pair._2.head)
-    val stages                                  = ArrayBuffer[CompressorStageSolution]()
+    val timeAndHeaps: Map[Int, BitHeap[BigInt]] =
+      bitHeapGroup.bitHeaps.groupBy(_.time).map(pair => pair._1 -> pair._2.head)
+    val stages = ArrayBuffer[CompressorStageSolution]()
 
     var currentTime = timeAndHeaps.keys.min
     var currentHeap = timeAndHeaps(currentTime)
 
-    // TODO: allow unpipelined stage
     while (currentTime < timeAndHeaps.keys.max) {
+      nextTimeHeap = timeAndHeaps.get(currentTime + 1)
+      nextHeapCarry.clear()
       stages += solveStage(currentHeap)
       if (stages.last.pipelined) {
         timeAndHeaps.get(currentTime + 1) match {
@@ -37,99 +95,172 @@ abstract class BitHeapSolver {
         currentTime += 1
       }
     }
-
-    while (currentHeap.heightMax > 3) stages += solveStage(currentHeap)
+    startInferPipeline = true
+    while (currentHeap.heightMax > 3) {
+      stages += solveStage(currentHeap)
+      if (verbose >= 1)
+        logger.info(s"${if (stages.last.pipelined) "stage pipelined"
+        else "stage not pipeline"}")
+    }
+    solveStageIndex = 1
     CompressorFullSolution(stages)
   }
 
-  // TODO: remove this and leave the interface in BitHeapGroup only
-  def solveAll(bitHeap: BitHeap[BigInt]): CompressorFullSolution = {
-    bitHeap.absorbConstant()
-    val stages = ArrayBuffer[CompressorStageSolution]()
-    while (bitHeap.heightMax > 3) stages += solveStage(bitHeap)
-    CompressorFullSolution(stages)
+  def solveStage(bitHeap: BitHeap[BigInt]): CompressorStageSolution = {
+    import bitHeap._
+    val initialBitCount    = bitsCount
+    val initialHeightMax   = heightMax
+    var totalCost          = 0.0
+    var stagePipelineState = refreshPipelineState(bitHeap)
+
+    val steps    = ArrayBuffer[CompressorStepSolution]()
+    val heapOuts = ArrayBuffer[BitHeap[BigInt]]()
+    while (nonEmpty) {
+      val stepSolution = solveStep(bitHeap)
+      steps += stepSolution
+      totalCost += stepSolution.compressorScores.cost
+      heapOuts += implStepSoft(stepSolution)
+    }
+    val heapNext: BitHeap[BigInt] = heapOuts.reduce(_ + _)
+    asSoft.absorbHeapFrom(heapNext)
+
+    if (verbose >= 1)
+      logger.info(
+        s"----------------Solve stage $solveStageIndex by $this----------------"
+      )
+    solveStageIndex += 1
+    if (heightMax <= 3 || reachLastStage) stagePipelineState = true
+
+    CompressorStageSolution(
+      steps,
+      initialHeightMax,
+      heightMax,
+      pipelined = stagePipelineState
+    )
   }
 
-  def solveStage(bitHeap: BitHeap[BigInt]): CompressorStageSolution
+  def solveStep(bitHeap: BitHeap[BigInt]): CompressorStepSolution
 
   type TestCase = Seq[ArithInfo]
+
+  override def toString: String = solverName
 
 }
 
 object NaiveSolver extends BitHeapSolver {
 
-  def apply(bitHeapGroup: BitHeapGroup[BigInt]): CompressorFullSolution = solveAll(bitHeapGroup)
+  def apply(bitHeapGroup: BitHeapGroup[BigInt]): CompressorFullSolution =
+    solveAll(bitHeapGroup)
 
-  def apply(bitHeap: BitHeap[BigInt]): CompressorFullSolution = solveAll(bitHeap)
+  def apply(bitHeap: BitHeap[BigInt]): CompressorFullSolution = solveAll(
+    BitHeapGroup(ArrayBuffer(bitHeap))
+  )
 
-  override def solveStage(bitHeap: BitHeap[BigInt]): CompressorStageSolution = {
+  override def solveStep(bitHeap: BitHeap[BigInt]): CompressorStepSolution = {
 
     import bitHeap._
 
     def isLastStage = heightMax <= 6
 
-    def solveStep: CompressorStepSolution = {
-      if (!isLastStage) {
-        val columnIdx = heap.indexWhere(_.nonEmpty)
-        val endIdx    = heap.lastIndexWhere(_.nonEmpty)
-        val width     = ((endIdx - columnIdx + 1) min cpaWidthMax) max 8
-        CompressorStepSolution(compressorName = "Compressor3to1", width, columnIdx, getExactScores(Compressor3to1(width), columnIdx, shouldPipeline = true))
-      } else {
-        val columnIdx = heap.indexWhere(_.nonEmpty)
-        CompressorStepSolution(compressorName = "Compressor6to3", width, columnIdx, getExactScores(Compressor6to3(), columnIdx, shouldPipeline = true))
-      }
+    if (!isLastStage) {
+      val maxHeightColumnIndex = heap.indexWhere(_.nonEmpty)
+      val endIdx               = heap.lastIndexWhere(_.nonEmpty)
+      val width                = ((endIdx - maxHeightColumnIndex + 1) min cpaWidthMax) max 8
+      CompressorStepSolution(
+        compressorName = "Compressor3to1",
+        width,
+        maxHeightColumnIndex,
+        getExactScores(
+          Compressor3to1(width),
+          maxHeightColumnIndex,
+          shouldPipeline = true
+        )
+      )
+    } else {
+      val maxHeightColumnIndex = heap.indexWhere(_.nonEmpty)
+      CompressorStepSolution(
+        compressorName = "Compressor6to3",
+        width,
+        maxHeightColumnIndex,
+        getExactScores(
+          Compressor6to3(),
+          maxHeightColumnIndex,
+          shouldPipeline = true
+        )
+      )
     }
-
-    val steps    = ArrayBuffer[CompressorStepSolution]()
-    val heapOuts = ArrayBuffer[BitHeap[BigInt]]()
-    while (nonEmpty) {
-      val stepSolution = solveStep
-      steps += stepSolution
-      heapOuts += implStepSoft(stepSolution)
-    }
-    val heapNext: BitHeap[BigInt] = heapOuts.reduce(_ + _)
-    asSoft.absorbHeapFrom(heapNext)
-    if (verbose >= 1) logger.info(s"----------------\n$this----------------\n")
-    CompressorStageSolution(steps, heightMax, pipelined = true)
   }
 }
 
 object GreedSolver extends BitHeapSolver {
+  def apply(bitHeapGroup: BitHeapGroup[BigInt]): CompressorFullSolution =
+    solveAll(bitHeapGroup)
 
-  override def solveStage(bitHeap: BitHeap[BigInt]): CompressorStageSolution = {
+  def apply(bitHeap: BitHeap[BigInt]): CompressorFullSolution = solveAll(
+    BitHeapGroup(ArrayBuffer(bitHeap))
+  )
+
+  override def solveStep(bitHeap: BitHeap[BigInt]): CompressorStepSolution = {
 
     import bitHeap._
-    def solveStep: CompressorStepSolution = {
-      val columnIndex             = heights.indexWhere(_ == heightMax)
-      var bestCompressor          = getCompressor("Compressor1to1", 1)
-      var bestReductionEfficiency = bestCompressor.reductionEfficiency()
-      var bestHeightReduction     = bestCompressor.heightReduction
 
-      val candidates = candidateCompressors.sortBy(compressor => compressor.reductionEfficiency()).reverse
+    val maxHeightColumnIndex    = heights.indexWhere(_ == heightMax)
+    var bestCompressor          = getCompressor("Compressor1to1", 1)
+    var bestReductionEfficiency = 0.0
+    var bestHeightReduction     = bestCompressor.heightReduction
 
-      candidates.foreach {
+    val candidates = candidateCompressors
+      .sortBy(compressor => compressor.reductionEfficiency)
+      .reverse
+
+    candidates.foreach { compressor =>
+      // get covered complementHeap
+      val bitCoveredComplementHeap =
+        compressor.inputFormat
+          .zip(complementHeap.drop(maxHeightColumnIndex))
+          .map { case (h, cHeap) =>
+            cHeap.take(h)
+          }
+      compressor match {
         case gpc: Gpc =>
-          val exactScores = getExactScores(gpc, columnIndex, shouldPipeline = true)
+          val searchedGpc =
+            getCompressor(gpc.name, -1, bitCoveredComplementHeap)
+          val exactScores =
+            getExactScores(
+              searchedGpc,
+              maxHeightColumnIndex,
+              pipelineState
+            )
           if (exactScores.reductionEfficiency >= bestReductionEfficiency) {
             if (exactScores.reductionEfficiency == bestReductionEfficiency) {
               if (exactScores.heightReduction >= bestHeightReduction) {
                 bestReductionEfficiency = exactScores.reductionEfficiency
-                bestCompressor          = gpc
+                bestCompressor          = searchedGpc
                 bestHeightReduction     = exactScores.heightReduction
               }
             } else {
               bestReductionEfficiency = exactScores.reductionEfficiency
-              bestCompressor          = gpc
+              bestCompressor          = searchedGpc
               bestHeightReduction     = exactScores.heightReduction
             }
           }
         case rowAdder: RowAdder =>
-          val searchWidthMax = rowAdder.widthMax min (bitHeap.width - columnIndex)
+          val searchWidthMax =
+            rowAdder.widthMax min (bitHeap.width - maxHeightColumnIndex)
           if (searchWidthMax >= rowAdder.widthMin) {
             var searchWidth = searchWidthMax
             while (searchWidth >= rowAdder.widthMin) {
-              val searchedRowAdder = getCompressor(rowAdder.name.split('_').head, searchWidth)
-              val exactScores      = getExactScores(searchedRowAdder, columnIndex, shouldPipeline = true)
+              val searchedRowAdder =
+                getCompressor(
+                  rowAdder.name,
+                  searchWidth,
+                  bitCoveredComplementHeap
+                )
+              val exactScores = getExactScores(
+                searchedRowAdder,
+                maxHeightColumnIndex,
+                pipelineState
+              )
               if (exactScores.reductionEfficiency >= (bestReductionEfficiency max 1.0)) {
                 if (exactScores.reductionEfficiency == bestReductionEfficiency) {
                   if (exactScores.heightReduction >= bestHeightReduction) {
@@ -144,44 +275,707 @@ object GreedSolver extends BitHeapSolver {
                 }
               }
 
-              if ((exactScores.reductionEfficiency + 0.2) < 1.0) {
+              if ((exactScores.reductionEfficiency + searchThreshold) < 1.0) {
                 searchWidth = 8 * floor((searchWidth - 1) / 8).toInt
               } else
                 searchWidth -= 1
             }
           }
       }
-      bestCompressor match {
-        case gpc: Gpc           => CompressorStepSolution(gpc.name.split('_').head, -1, columnIndex, getExactScores(gpc, columnIndex, shouldPipeline = true))
-        case rowAdder: RowAdder => CompressorStepSolution(rowAdder.name.split('_').head, rowAdder.width, columnIndex, getExactScores(rowAdder, columnIndex, shouldPipeline = true))
-      }
+    }
+    bestCompressor match {
+      case gpc: Gpc =>
+        CompressorStepSolution(
+          gpc.name,
+          -1,
+          maxHeightColumnIndex,
+          getExactScores(gpc, maxHeightColumnIndex, pipelineState)
+        )
+      case rowAdder: RowAdder =>
+        CompressorStepSolution(
+          rowAdder.name,
+          rowAdder.width,
+          maxHeightColumnIndex,
+          getExactScores(
+            rowAdder,
+            maxHeightColumnIndex,
+            pipelineState
+          )
+        )
     }
 
-    val steps    = ArrayBuffer[CompressorStepSolution]()
-    val heapOuts = ArrayBuffer[BitHeap[BigInt]]()
-    while (nonEmpty) {
-      val stepSolution = solveStep
-      steps += stepSolution
-      heapOuts += implStepSoft(stepSolution)
-    }
-    val heapNext: BitHeap[BigInt] = heapOuts.reduce(_ + _)
-    asSoft.absorbHeapFrom(heapNext)
-    CompressorStageSolution(steps, heightMax, pipelined = true)
   }
 }
 
-object TailOptimizedSlover extends BitHeapSolver {
-  def apply(bitHeapGroup: BitHeapGroup[BigInt]): CompressorFullSolution = solveAll(bitHeapGroup)
+abstract class ConditionalStrategySolver(
+    val headBound: Double,
+    val tailBound: Double
+) extends BitHeapSolver {
 
-  def apply(bitHeap: BitHeap[BigInt]): CompressorFullSolution = solveAll(bitHeap)
+  private var useHeadStrategy = true
+  inferPipelineMode = true
 
-  override def solveStage(bitHeap: BitHeap[BigInt]): CompressorStageSolution = ???
+  def headStrategy(bitHeap: BitHeap[BigInt]): CompressorStepSolution
+
+  def tailStrategy(bitHeap: BitHeap[BigInt]): CompressorStepSolution
+
+  override def solveStep(bitHeap: BitHeap[BigInt]): CompressorStepSolution =
+    if (useHeadStrategy) headStrategy(bitHeap) else tailStrategy(bitHeap)
+
+  override def solveStage(bitHeap: BitHeap[BigInt]): CompressorStageSolution = {
+    useHeadStrategy = !bitHeap.reachLastStage
+    if (verbose >= 1)
+      logger.info(
+        s"use ${if (useHeadStrategy) "HeadStrategy" else "TailStrategy"} in Step solve"
+      )
+    val stageSolution = super.solveStage(bitHeap)
+    stageSolution
+  }
 }
 
-object TailAndHeightOptimizedSlover extends BitHeapSolver {
-  def apply(bitHeapGroup: BitHeapGroup[BigInt]): CompressorFullSolution = solveAll(bitHeapGroup)
+object StrategySeparationSolver extends ConditionalStrategySolver(headBound = 1.0, tailBound = 0.2) {
+  def apply(bitHeapGroup: BitHeapGroup[BigInt]): CompressorFullSolution =
+    solveAll(bitHeapGroup)
 
-  def apply(bitHeap: BitHeap[BigInt]): CompressorFullSolution = solveAll(bitHeap)
+  def apply(bitHeap: BitHeap[BigInt]): CompressorFullSolution = solveAll(
+    BitHeapGroup(ArrayBuffer(bitHeap))
+  )
 
-  override def solveStage(bitHeap: BitHeap[BigInt]): CompressorStageSolution = ???
+  val greedSolver = GreedSolver
+
+  override def headStrategy(
+      bitHeap: BitHeap[BigInt]
+  ): CompressorStepSolution = {
+    greedSolver.absorbMetaInfosFrom(this)
+    greedSolver.solveStep(bitHeap)
+  }
+
+  override def tailStrategy(
+      bitHeap: BitHeap[BigInt]
+  ): CompressorStepSolution = {
+    import bitHeap._
+
+    val maxHeightColumnIndex    = heights.indexWhere(_ == heightMax)
+    var bestCompressor          = getCompressor("Compressor1to1", 1)
+    var bestReductionEfficiency = 0.0
+    var bestHeightReduction     = bestCompressor.heightReduction
+
+    val candidates = candidateCompressors
+      .sortBy(compressor => compressor.reductionEfficiency)
+      .reverse
+
+    candidates.foreach { compressor =>
+      // get covered complementHeap
+      val bitCoveredComplementHeap =
+        compressor.inputFormat
+          .zip(complementHeap.drop(maxHeightColumnIndex))
+          .map { case (h, cHeap) =>
+            cHeap.take(h)
+          }
+      compressor match {
+        case gpc: Gpc =>
+          val searchedGpc =
+            getCompressor(gpc.name, -1, bitCoveredComplementHeap)
+          val exactScores =
+            getExactScores(
+              searchedGpc,
+              maxHeightColumnIndex,
+              shouldPipeline = pipelineState
+            )
+          if (exactScores.heightReduction >= bestHeightReduction) {
+            if (exactScores.heightReduction == bestHeightReduction) {
+              if (exactScores.reductionEfficiency >= bestReductionEfficiency) {
+                bestReductionEfficiency = exactScores.reductionEfficiency
+                bestCompressor          = searchedGpc
+                bestHeightReduction     = exactScores.heightReduction
+              }
+            } else {
+              bestReductionEfficiency = exactScores.reductionEfficiency
+              bestCompressor          = searchedGpc
+              bestHeightReduction     = exactScores.heightReduction
+            }
+          }
+        case rowAdder: RowAdder =>
+          val searchWidthMax =
+            rowAdder.widthMax min (bitHeap.width - maxHeightColumnIndex)
+          if (searchWidthMax >= rowAdder.widthMin) {
+            var searchWidth = searchWidthMax
+            while (searchWidth >= rowAdder.widthMin) {
+              val searchedRowAdder =
+                getCompressor(
+                  rowAdder.name,
+                  searchWidth,
+                  bitCoveredComplementHeap
+                )
+              val exactScores = getExactScores(
+                searchedRowAdder,
+                maxHeightColumnIndex,
+                shouldPipeline = pipelineState
+              )
+              if (exactScores.heightReduction >= bestHeightReduction) {
+                if (exactScores.heightReduction == bestHeightReduction) {
+                  if (exactScores.reductionEfficiency >= (bestReductionEfficiency max 1.0)) {
+                    bestReductionEfficiency = exactScores.reductionEfficiency
+                    bestCompressor          = searchedRowAdder
+                    bestHeightReduction     = exactScores.heightReduction
+                  }
+                } else {
+                  bestReductionEfficiency = exactScores.reductionEfficiency
+                  bestCompressor          = searchedRowAdder
+                  bestHeightReduction     = exactScores.heightReduction
+                }
+              }
+
+              if ((exactScores.reductionEfficiency + searchThreshold) < 1.0) {
+                searchWidth = 8 * floor((searchWidth - 1) / 8).toInt
+              } else
+                searchWidth -= 1
+            }
+          }
+      }
+    }
+    bestCompressor match {
+      case gpc: Gpc =>
+        CompressorStepSolution(
+          gpc.name,
+          -1,
+          maxHeightColumnIndex,
+          getExactScores(gpc, maxHeightColumnIndex, pipelineState)
+        )
+      case rowAdder: RowAdder =>
+        CompressorStepSolution(
+          rowAdder.name,
+          rowAdder.width,
+          maxHeightColumnIndex,
+          getExactScores(
+            rowAdder,
+            maxHeightColumnIndex,
+            pipelineState
+          )
+        )
+    }
+  }
+}
+
+object StrategySeparationOptimizedSolver extends ConditionalStrategySolver(headBound = 1.0, tailBound = 0.2) {
+  def apply(bitHeapGroup: BitHeapGroup[BigInt]): CompressorFullSolution =
+    solveAll(bitHeapGroup)
+
+  def apply(bitHeap: BitHeap[BigInt]): CompressorFullSolution = solveAll(
+    BitHeapGroup(ArrayBuffer(bitHeap))
+  )
+
+  def isNeedSkipSearch(heap: BitHeap[BigInt]): Boolean = {
+    import heap._
+
+    val maxHeightColumnIndex                                          = heights.indexWhere(_ == heightMax)
+    var nextHeapHeightInCurrentPosition, nextHeapHeightInNextPosition = 0
+    nextTimeHeap match {
+      case Some(nextHeap) =>
+        val positionInNextHeap =
+          weightLow + maxHeightColumnIndex - nextHeap.weightLow
+        if (positionInNextHeap == -1)
+          nextHeapHeightInNextPosition = nextHeap.heights.head
+        if (positionInNextHeap >= 0) {
+          if (positionInNextHeap <= nextHeap.heights.length - 2) {
+            nextHeapHeightInCurrentPosition = nextHeap.heights(positionInNextHeap)
+            nextHeapHeightInNextPosition    = nextHeap.heights(positionInNextHeap + 1)
+          }
+          if (positionInNextHeap == nextHeap.heights.length - 1) {
+            nextHeapHeightInCurrentPosition = nextHeap.heights(positionInNextHeap)
+          }
+        }
+      case None =>
+    }
+
+    var skipCompressorSearch = heights(maxHeightColumnIndex) == 1
+    def currentColumnNeedKeep = heights(maxHeightColumnIndex) +
+      nextHeapCarry.getOrElse(maxHeightColumnIndex, 0) +
+      nextHeapHeightInCurrentPosition == 3
+    def nextColumnNeedCarry = heights(maxHeightColumnIndex + 1) +
+      nextHeapCarry.getOrElse(maxHeightColumnIndex + 1, 0) +
+      nextHeapHeightInNextPosition == 2
+    val needConsiderSkipSearch =
+      heights(maxHeightColumnIndex) == 2 && maxHeightColumnIndex <= width - 2
+    val needConsiderLastColumn =
+      heights(maxHeightColumnIndex) == 2 && maxHeightColumnIndex == width - 1
+    if (needConsiderSkipSearch) {
+      if (pipelineState)
+        skipCompressorSearch    = currentColumnNeedKeep || (!currentColumnNeedKeep && !nextColumnNeedCarry)
+      else skipCompressorSearch = currentColumnNeedKeep
+    } else if (needConsiderLastColumn) {
+      if (pipelineState)
+        skipCompressorSearch = nextHeapCarry.getOrElse(maxHeightColumnIndex, 0) +
+          nextHeapHeightInCurrentPosition == 0
+      else
+        skipCompressorSearch = nextHeapCarry.getOrElse(maxHeightColumnIndex, 0) +
+          nextHeapHeightInCurrentPosition <= 1
+    }
+    skipCompressorSearch
+  }
+
+  def compareRowAdder(
+      heap: BitHeap[BigInt],
+      bestRowAdder: RowAdder,
+      candidateRowAdder: RowAdder,
+      startColumnIndex: Int
+  ): Boolean = {
+    import heap._
+    val candidateHeaps = Seq.fill(2)(
+      BitHeap.fromHeights(
+        heights.drop(startColumnIndex),
+        weightLow + startColumnIndex,
+        time = 0
+      )
+    )
+
+    val firstStageReductionBits  = ArrayBuffer.fill(2)(0)
+    val firstStageCost           = ArrayBuffer(0.0, 0.0)
+    val secondStageReductionBits = ArrayBuffer.fill(2)(0)
+    val secondStageCost          = ArrayBuffer.fill(2)(0.0)
+
+    Seq(bestRowAdder.width, candidateRowAdder.width)
+      .zip(Seq(bestRowAdder, candidateRowAdder).zipWithIndex)
+      .foreach { case (searchWidth, (compressor, i)) =>
+//        val exactReductionEfficiency =
+//          candidateHeaps(i).getExactScores(
+//            compressor,
+//            columnIndex = 0,
+//            shouldPipeline = pipelineState
+//          ).reductionEfficiency
+        firstStageCost(i) = compressor.clbCost
+        firstStageReductionBits(i) = compressor.inputFormat
+          .zip(candidateHeaps(i).heap)
+          .map { case (number, column) =>
+            val exactNumber = column.length min number
+            val slice       = column.take(exactNumber)
+            column --= slice
+            slice
+          }
+          .map(_.length)
+          .sum - compressor.outputBitsCount
+      }
+
+    val secondStageHeights =
+      candidateHeaps.zip(Seq(bestRowAdder.width, candidateRowAdder.width)).map { case (bitHeap, width) =>
+        bitHeap.heights.take(width)
+      }
+
+    secondStageHeights
+      .zip(Seq.fill(2)(Seq(bestRowAdder, candidateRowAdder)).zipWithIndex)
+      .foreach { case (heights, (candidateComp, i)) =>
+        if (heights.forall(_ == 0)) {
+          secondStageReductionBits(i) = 0
+          secondStageCost(i)          = 0.0
+        } else {
+          val startColumnIndex    = heights.indexWhere(_ == heights.max)
+          val stageBestEfficiency = ArrayBuffer.fill(2)(ArrayBuffer(0.0, 0.0))
+          val stageBestCompressor = ArrayBuffer.fill(2)(
+            ArrayBuffer(bestRowAdder, candidateRowAdder)
+          )
+          val stageBestWidth =
+            ArrayBuffer.fill(2)(
+              ArrayBuffer(bestRowAdder.width, candidateRowAdder.width)
+            )
+
+          candidateComp.zipWithIndex.foreach { case (compressor, j) =>
+            var searchWidth =
+              (heights.length - startColumnIndex) min compressor.widthMax
+            while (searchWidth >= compressor.widthMin) {
+              val exactReductionEfficiency =
+                candidateHeaps(i)
+                  .getExactScores(
+                    compressor,
+                    startColumnIndex,
+                    pipelineState
+                  )
+                  .reductionEfficiency
+              if (
+                exactReductionEfficiency >= (stageBestEfficiency(i)(
+                  j
+                ) max headBound)
+              ) {
+                stageBestEfficiency(i)(j) = exactReductionEfficiency
+                stageBestCompressor(i)(j) = compressor
+                stageBestWidth(i)(j)      = searchWidth
+              }
+              if ((exactReductionEfficiency + searchThreshold) < headBound)
+                searchWidth = 8 * floor((searchWidth - 1) / 8).toInt
+              else searchWidth -= 1
+            }
+          }
+
+          val (bestEfficiency, (bestCompressor, bestWidth)) =
+            stageBestEfficiency(i)
+              .zip(stageBestCompressor(i).zip(stageBestWidth(i)))
+              .maxBy(_._1)
+          if (bestEfficiency >= headBound) {
+            secondStageCost(i) = bestCompressor.clbCost
+            secondStageReductionBits(i) = bestCompressor.inputFormat
+              .zip(candidateHeaps(i).heap.drop(startColumnIndex))
+              .map { case (number, column) =>
+                val exactNumber = column.length min number
+                val slice       = column.take(exactNumber)
+                slice
+              }
+              .map(_.length)
+              .sum - bestCompressor.outputBitsCount
+          } else {
+            secondStageCost(i)          = math.log(heights.sum) / math.log(2)
+            secondStageReductionBits(i) = ceil(math.log(heights.sum) / math.log(3)).toInt
+          }
+
+        }
+
+      }
+
+    val finalReductionBits =
+      firstStageReductionBits.zip(secondStageReductionBits).map { case (first, second) =>
+        first + second
+      }
+    val finalCost = firstStageCost.zip(secondStageCost).map { case (first, second) =>
+      first + second
+    }
+    val finalEfficiency = finalReductionBits.zip(finalCost).map { case (reduction, cost) =>
+      reduction / cost
+    }
+    var compareResult = true
+    if (
+      finalEfficiency.head < finalEfficiency.last || (finalEfficiency.head == finalEfficiency.last && bestRowAdder.inputFormat.sum < candidateRowAdder.inputFormat.sum)
+    ) compareResult = false
+    //    logger.info(s"win ${if (compareResult) lastBestCompressor.name else newBestCompressor.name}")
+    //    logger.info(s"heights: ${secondStageHeights.map(_.mkString(",")).mkString("\n")}")
+    //    logger.info(s"seconds: ${seconds.mkString(",")}")
+    compareResult
+  }
+
+  override def headStrategy(
+      bitHeap: BitHeap[BigInt]
+  ): CompressorStepSolution = {
+    import bitHeap._
+
+    // find the first(lowest weight) column with maximum height
+    val maxHeightColumnIndex    = heights.indexWhere(_ == heightMax)
+    var bestCompressor          = getCompressor("Compressor1to1", 1)
+    var bestReductionEfficiency = 0.0
+    var bestHeightReduction     = bestCompressor.heightReduction
+
+    candidateCompressors.foreach(_.setPipelineState(pipelineState))
+    val candidates = candidateCompressors.tail
+      .sortBy(compressor => compressor.reductionEfficiency)
+      .reverse
+
+    if (!isNeedSkipSearch(bitHeap)) {
+      var exactScores = ScoreIndicator(0, 0, 0, 0, 0)
+      def betterEfficiency =
+        exactScores.reductionEfficiency > (bestReductionEfficiency max headBound)
+      def sameEfficiency =
+        exactScores.reductionEfficiency == (bestReductionEfficiency max headBound)
+      def betterHeightReduction =
+        exactScores.heightReduction >= bestHeightReduction
+
+      candidates.foreach { compressor =>
+        // get covered complementHeap
+        val bitCoveredComplementHeap =
+          compressor.inputFormat
+            .zip(complementHeap.drop(maxHeightColumnIndex))
+            .map { case (h, cHeap) =>
+              cHeap.take(h)
+            }
+        compressor match {
+          case gpc: Gpc =>
+            val searchedGpc =
+              getCompressor(gpc.name, -1, bitCoveredComplementHeap)
+            exactScores = getExactScores(
+              searchedGpc,
+              maxHeightColumnIndex,
+              pipelineState
+            )
+
+            if (betterEfficiency) {
+              bestReductionEfficiency = exactScores.reductionEfficiency
+              bestCompressor          = searchedGpc
+              bestHeightReduction     = exactScores.heightReduction
+            } else if (sameEfficiency && betterHeightReduction) {
+              bestReductionEfficiency = exactScores.reductionEfficiency
+              bestCompressor          = searchedGpc
+              bestHeightReduction     = exactScores.heightReduction
+            }
+          case rowAdder: RowAdder =>
+            val searchWidthMax =
+              rowAdder.widthMax min (bitHeap.width - maxHeightColumnIndex)
+            if (searchWidthMax >= rowAdder.widthMin) {
+              var searchWidth = searchWidthMax
+              while (searchWidth >= rowAdder.widthMin) {
+                val searchedRowAdder =
+                  getCompressor(
+                    rowAdder.name,
+                    searchWidth,
+                    bitCoveredComplementHeap
+                  ).asInstanceOf[RowAdder]
+                exactScores = getExactScores(
+                  searchedRowAdder,
+                  maxHeightColumnIndex,
+                  pipelineState
+                )
+
+                bestCompressor match {
+                  case adder: RowAdder =>
+                    if (
+                      compareRowAdder(
+                        bitHeap,
+                        searchedRowAdder,
+                        adder,
+                        maxHeightColumnIndex
+                      )
+                    ) {
+                      bestReductionEfficiency = exactScores.reductionEfficiency
+                      bestCompressor          = searchedRowAdder
+                      bestHeightReduction     = exactScores.heightReduction
+                    }
+                  case _ =>
+                    if (betterEfficiency) {
+                      bestReductionEfficiency = exactScores.reductionEfficiency
+                      bestCompressor          = searchedRowAdder
+                      bestHeightReduction     = exactScores.heightReduction
+                    } else if (sameEfficiency && betterHeightReduction) {
+                      bestReductionEfficiency = exactScores.reductionEfficiency
+                      bestCompressor          = searchedRowAdder
+                      bestHeightReduction     = exactScores.heightReduction
+                    }
+                }
+
+                if ((exactScores.reductionEfficiency + searchThreshold) < 1.0) {
+                  searchWidth = 8 * floor((searchWidth - 1) / 8).toInt
+                } else
+                  searchWidth -= 1
+              }
+            }
+        }
+      }
+
+      if (bestCompressor.outputFormat.length > 1) {
+        bestCompressor.outputFormat.zipWithIndex.foreach { case (h, i) =>
+          val oldRecord = nextHeapCarry.get(maxHeightColumnIndex + i)
+          oldRecord match {
+            case Some(old) =>
+              nextHeapCarry.remove(maxHeightColumnIndex + i)
+              nextHeapCarry.put(maxHeightColumnIndex + i, old + h)
+            case None =>
+              nextHeapCarry.put(maxHeightColumnIndex + i, h)
+          }
+        }
+      }
+    }
+    bestCompressor match {
+      case gpc: Gpc =>
+        CompressorStepSolution(
+          gpc.name,
+          -1,
+          maxHeightColumnIndex,
+          getExactScores(gpc, maxHeightColumnIndex, pipelineState)
+        )
+      case rowAdder: RowAdder =>
+        CompressorStepSolution(
+          rowAdder.name,
+          rowAdder.width,
+          maxHeightColumnIndex,
+          getExactScores(
+            rowAdder,
+            maxHeightColumnIndex,
+            pipelineState
+          )
+        )
+    }
+  }
+
+  override def tailStrategy(
+      bitHeap: BitHeap[BigInt]
+  ): CompressorStepSolution = {
+    import bitHeap._
+
+    val maxHeightColumnIndex    = heights.indexWhere(_ == heightMax)
+    var bestCompressor          = getCompressor("Compressor1to1", 1)
+    var bestReductionEfficiency = 0.0
+    var bestHeightReduction     = bestCompressor.heightReduction
+
+    val gpcs = candidateCompressors
+      .filter(_.isInstanceOf[Gpc])
+      .sortBy(compressor => compressor.reductionEfficiency)
+      .reverse
+
+    val rowAdderEfficiencyTable = candidateCompressors
+      .filter(_.isInstanceOf[RowAdder])
+      .flatMap { rowAdder =>
+        val (widthMax, widthMin) = (
+          rowAdder
+            .asInstanceOf[RowAdder]
+            .widthMax,
+          rowAdder
+            .asInstanceOf[RowAdder]
+            .widthMin
+        )
+        // get covered complementHeap
+        val bitCoveredComplementHeap =
+          rowAdder.inputFormat
+            .zip(complementHeap.drop(maxHeightColumnIndex))
+            .map { case (h, cHeap) =>
+              cHeap.take(h)
+            }
+        Range
+          .inclusive(
+            (width - maxHeightColumnIndex) min widthMax,
+            1,
+            -1
+          )
+          .filter(_ >= widthMin)
+          .map { w =>
+            getCompressor(rowAdder.name, w, bitCoveredComplementHeap)
+              .asInstanceOf[RowAdder] ->
+              getExactScores(
+                rowAdder,
+                maxHeightColumnIndex,
+                pipelineState
+              ).reductionEfficiency
+          }
+      }
+    val maxEfficiencyRowAdder = rowAdderEfficiencyTable
+      .filter { case (_, efficiency) =>
+        efficiency == rowAdderEfficiencyTable.maxBy(_._2)._2
+      }
+      .maxBy(_._1.heightReduction)
+
+    val needGpcSearch = if (maxEfficiencyRowAdder._2 > 1.0) {
+      val rowAdderWidth = maxEfficiencyRowAdder._1.inputFormat.length
+      if (!pipelineState) {
+        if (
+          rowAdderWidth + maxHeightColumnIndex != width && heights(
+            rowAdderWidth + maxHeightColumnIndex
+          ) + nextHeapCarry.getOrElse(
+            rowAdderWidth + maxHeightColumnIndex,
+            0
+          ) > 1
+        ) true
+        else false
+      } else {
+        if (rowAdderWidth + maxHeightColumnIndex != width) true
+        else false
+      }
+    } else true
+
+    if (!needGpcSearch) {
+      bestCompressor          = maxEfficiencyRowAdder._1
+      bestReductionEfficiency = maxEfficiencyRowAdder._2
+    }
+
+    if (!isNeedSkipSearch(bitHeap) && needGpcSearch) {
+      gpcs.foreach { gpc =>
+        val exactScores =
+          getExactScores(
+            gpc,
+            maxHeightColumnIndex,
+            shouldPipeline = pipelineState
+          )
+        if (exactScores.heightReduction >= bestHeightReduction) {
+          if (exactScores.heightReduction == bestHeightReduction) {
+            if (exactScores.reductionEfficiency >= bestReductionEfficiency) {
+              bestReductionEfficiency = exactScores.reductionEfficiency
+              bestCompressor          = gpc
+              bestHeightReduction     = exactScores.heightReduction
+            }
+          } else {
+            bestReductionEfficiency = exactScores.reductionEfficiency
+            bestCompressor          = gpc
+            bestHeightReduction     = exactScores.heightReduction
+          }
+        }
+      }
+    }
+
+    if (bestCompressor.outputFormat.length > 1) {
+      bestCompressor.outputFormat.zipWithIndex.foreach { case (h, i) =>
+        val oldRecord = nextHeapCarry.get(maxHeightColumnIndex + i)
+        oldRecord match {
+          case Some(old) =>
+            nextHeapCarry.remove(maxHeightColumnIndex + i)
+            nextHeapCarry.put(maxHeightColumnIndex + i, old + h)
+          case None =>
+            nextHeapCarry.put(maxHeightColumnIndex + i, h)
+        }
+      }
+    }
+
+    bestCompressor match {
+      case gpc: Gpc =>
+        CompressorStepSolution(
+          gpc.name,
+          -1,
+          maxHeightColumnIndex,
+          getExactScores(gpc, maxHeightColumnIndex, pipelineState)
+        )
+      case rowAdder: RowAdder =>
+        CompressorStepSolution(
+          rowAdder.name,
+          rowAdder.width,
+          maxHeightColumnIndex,
+          getExactScores(
+            rowAdder,
+            maxHeightColumnIndex,
+            pipelineState
+          )
+        )
+    }
+  }
+
+}
+
+object TernaryTreeSolver extends BitHeapSolver {
+  def apply(bitHeapGroup: BitHeapGroup[BigInt]): CompressorFullSolution =
+    solveAll(bitHeapGroup)
+
+  def apply(bitHeap: BitHeap[BigInt]): CompressorFullSolution = solveAll(
+    BitHeapGroup(ArrayBuffer(bitHeap))
+  )
+
+  override def solveStep(bitHeap: BitHeap[BigInt]): CompressorStepSolution = {
+    import bitHeap._
+    val maxHeightColumnIndex = heap.indexWhere(_.nonEmpty)
+    val endIdx               = heap.lastIndexWhere(_.nonEmpty)
+    val width                = ((endIdx - maxHeightColumnIndex + 1) min cpaWidthMax) max 8
+    CompressorStepSolution(
+      compressorName = "Compressor3to1",
+      width,
+      maxHeightColumnIndex,
+      getExactScores(
+        Compressor3to1(width),
+        maxHeightColumnIndex,
+        pipelineState
+      )
+    )
+  }
+}
+
+object GpcSolver extends BitHeapSolver {
+  def apply(bitHeapGroup: BitHeapGroup[BigInt]): CompressorFullSolution =
+    solveAll(bitHeapGroup)
+
+  def apply(bitHeap: BitHeap[BigInt]): CompressorFullSolution = solveAll(
+    BitHeapGroup(ArrayBuffer(bitHeap))
+  )
+
+  override def solveStep(bitHeap: BitHeap[BigInt]): CompressorStepSolution = {
+    import bitHeap._
+    val maxHeightColumnIndex = heap.indexWhere(_.nonEmpty)
+    val bestCompressor = Gpcs().maxBy(gpc => getExactScores(gpc, maxHeightColumnIndex, pipelineState).heightReduction)
+    CompressorStepSolution(
+      compressorName = bestCompressor.name.firstBeforeChar('_'),
+      width,
+      maxHeightColumnIndex,
+      getExactScores(
+        bestCompressor,
+        maxHeightColumnIndex,
+        pipelineState
+      )
+    )
+  }
 }

--- a/src/main/scala/Chainsaw/arithmetic/bitheap/CompressorSolution.scala
+++ b/src/main/scala/Chainsaw/arithmetic/bitheap/CompressorSolution.scala
@@ -5,29 +5,50 @@ import Chainsaw.arithmetic.{CompressorGenerator, bitheap}
 
 import java.io._
 
-case class CompressorScores(bitReduction: Int, heightReduction: Int, reductionEfficiency: Double, reductionRatio: Double) {
+case class ScoreIndicator(
+    bitReduction: Int,
+    heightReduction: Int,
+    reductionEfficiency: Double,
+    reductionRatio: Double,
+    cost: Double
+) {
 
   /** compare two compressor according to current strategy
-   */
-  def >(that: CompressorScores)(implicit strategy: CompressionStrategy): Boolean = {
+    */
+  def >(
+      that: ScoreIndicator
+  )(implicit strategy: CompressionStrategy): Boolean = {
 
     val br = this.bitReduction compare that.bitReduction
     val hr = this.heightReduction compare that.heightReduction
     val re = this.reductionEfficiency compare that.reductionEfficiency
     val rr = this.reductionRatio compare that.reductionRatio
+    val co = this.cost compare that.cost
 
-    def det(compared: Seq[Int]) = compared.reverse.zipWithIndex.map { case (bit, weight) => bit << weight }.sum > 0
+    def det(compared: Seq[Int]) = compared.reverse.zipWithIndex.map { case (bit, weight) =>
+      bit << weight
+    }.sum > 0
 
     val priority = strategy match {
-      case ReFirst => Seq(re, hr, br, rr)
-      case HrFirst => Seq(hr, re, br, rr)
+      case ReFirst => Seq(re, hr, br, rr, co)
+      case HrFirst => Seq(hr, re, br, rr, co)
     }
     det(priority)
   }
 
-  def <=(that: CompressorScores)(implicit strategy: CompressionStrategy) = !(this > that)
+  def <=(that: ScoreIndicator)(implicit strategy: CompressionStrategy) =
+    !(this > that)
 
-  override def toString = s"CompressorScores(br = $bitReduction, hr = $heightReduction, re = $reductionEfficiency, rr = $reductionRatio)"
+  def toMap = Map(
+    "br"   -> bitReduction.toDouble,
+    "cost" -> cost,
+    "re"   -> reductionEfficiency,
+    "rr"   -> reductionRatio,
+    "hr"   -> heightReduction.toDouble
+  )
+
+  override def toString =
+    s"ScoresIndicator(br = $bitReduction, hr = $heightReduction, re = $reductionEfficiency, rr = $reductionRatio)"
 }
 
 @SerialVersionUID(42L)
@@ -35,9 +56,11 @@ case class CompressorFullSolution(stageSolutions: Seq[CompressorStageSolution]) 
 
   def latency = stageSolutions.count(_.pipelined)
 
-  def outHeight = if (stageSolutions.last.stageHeight == -1) 3 else stageSolutions.last.stageHeight
+  def outHeight = if (stageSolutions.last.stageOutHeight == -1) 3
+  else stageSolutions.last.stageOutHeight
 
-  override def vivadoUtilEstimation = stageSolutions.map(_.vivadoUtilEstimation).reduce(_ + _)
+  override def vivadoUtilEstimation =
+    stageSolutions.map(_.vivadoUtilEstimation).reduce(_ + _)
 
   def bitReduction = stageSolutions.map(_.bitReduction).sum
 
@@ -48,16 +71,87 @@ case class CompressorFullSolution(stageSolutions: Seq[CompressorStageSolution]) 
     oos.close()
   }
 
+  def scores: Map[String, Double] = {
+    val scoreSum = stageSolutions
+      .flatMap(_.scores)
+      .groupBy(_._1)
+      .map { case (k, v) =>
+        k match {
+          case "rr" => k -> v.map(_._2).sum / v.length
+          case _    => k -> v.map(_._2).sum
+        }
+      }
+    scoreSum.map { case (name, score) =>
+      name match {
+        case "re" =>
+          name -> scoreSum.getOrElse("br", 0.0) / scoreSum.getOrElse(
+            "cost",
+            0.0
+          )
+        case _ => name -> score
+      }
+    }
+  }
+
+  def toTable(
+      rows: Seq[Map[String, Double]],
+      tail: Map[String, Double] = null
+  ) = {
+    val scoreOrder = Seq("br", "cost", "re", "rr", "hr")
+    val sortedRows =
+      if (tail == null)
+        rows.map(row => scoreOrder.map(k => row.getOrElse(k, 0.0)))
+      else
+        (rows :+ tail).map(row => scoreOrder.map(k => row.getOrElse(k, 0.0)))
+
+    val colWidths = sortedRows.transpose
+      .map(col => col.map(_.toString.length).max)
+    val header =
+      ("Stage" +: scoreOrder.zip(colWidths).map { case (str, len) =>
+        s"${" " * ((len - str.length) / 2)}$str${" " * ((len + 1 - str.length) / 2)}"
+      }).mkString("| ", " | ", " |") + s"\n"
+    val separator = (5 +: colWidths)
+      .map(len => s"${"-" * len}")
+      .mkString("| ", " | ", " |") + s"\n"
+    val body = sortedRows.zipWithIndex
+      .map { case (scores, stage) =>
+        (s"${(if (stage + 1 == sortedRows.length && tail != null) "total"
+              else (stage + 1).toString).padTo(5, " ").mkString("")}" +:
+          scores
+            .zip(colWidths)
+            .map { case (score, len) =>
+              val scoreLength = score.toString.length
+              s"${" " * ((len - scoreLength) / 2)}${score.toString}${" " * ((len - scoreLength + 1) / 2)}"
+            })
+          .mkString("| ", " | ", " |")
+      }
+      .mkString("\n")
+    s"$header$separator$body"
+  }
+
+  override def toString = {
+    val rows = stageSolutions.map(_.scores)
+    val tail = scores
+    toTable(rows, tail)
+  }
+
   def report = {
-    val classReport = stageSolutions.flatMap(_.compressorSolutions)
+    val classReport = stageSolutions
+      .flatMap(_.compressorSolutions)
       .groupBy(_.compressorName)
-      .map { case (k, v) => k -> v.size }.mkString("\n")
+      .map { case (k, v) => k -> v.size }
+      .mkString("\n")
 
-    val subReport = stageSolutions.flatMap(_.compressorSolutions)
+    val subReport = stageSolutions
+      .flatMap(_.compressorSolutions)
       .groupBy(_.compressorName)
-      .map { case (k, v) => k -> v.map(_.getCompressor().vivadoUtilEstimation).reduce(_ + _) }.mkString("\n")
+      .map { case (k, v) =>
+        k -> v.map(_.getCompressor().vivadoUtilEstimation).reduce(_ + _)
+      }
+      .mkString("\n")
 
-    val briefReport = s"latency = $latency, reduction = $bitReduction, efficiency = ${bitReduction.toDouble / vivadoUtilEstimation.lut}"
+    val briefReport =
+      s"latency = $latency, reduction = $bitReduction, efficiency = ${bitReduction.toDouble / vivadoUtilEstimation.lut}"
 
     s"\n----bitheap compressor solution report:----" +
       s"\n--------performance--------" +
@@ -79,17 +173,58 @@ object CompressorFullSolution {
   }
 }
 
-case class CompressorStageSolution(compressorSolutions: Seq[CompressorStepSolution], stageHeight: Int, pipelined: Boolean) {
+case class CompressorStageSolution(
+    compressorSolutions: Seq[CompressorStepSolution],
+    stageInHeight: Int,
+    stageOutHeight: Int,
+    pipelined: Boolean
+) {
 
-  def vivadoUtilEstimation = compressorSolutions.map(_.vivadoUtilEstimation).reduce(_ + _)
+  def vivadoUtilEstimation =
+    compressorSolutions.map(_.vivadoUtilEstimation).reduce(_ + _)
 
-  def bitReduction = compressorSolutions.map(_.compressorScores.bitReduction).sum
+  def bitReduction =
+    compressorSolutions.map(_.compressorScores.bitReduction).sum
+
+  def scores = {
+    val scoreMerge = compressorSolutions
+      .flatMap(_.compressorScores.toMap)
+      .groupBy(_._1)
+      .map { case (k, v) =>
+        k match {
+          case "rr" => k -> v.map(_._2).sum / v.length
+          case "hr" => k -> (stageInHeight - stageOutHeight).toDouble
+          case _    => k -> v.map(_._2).sum
+        }
+      }
+    scoreMerge.map { case (k, v) =>
+      k match {
+        case "re" =>
+          k -> scoreMerge.getOrElse("br", 0.0) / scoreMerge.getOrElse(
+            "cost",
+            0.0
+          )
+        case _ => k -> v
+      }
+    }
+  }
 
 }
 
-case class CompressorStepSolution(compressorName: String, width: Int, columnIndex: Int, compressorScores: CompressorScores = CompressorScores(0, 0, 0, 0)) {
-  def getCompressor(complementHeap: Seq[Seq[Boolean]] = null): CompressorGenerator =
-    bitheap.getCompressor(compressorName, width, complementHeap)
+case class CompressorStepSolution(
+    compressorName: String,
+    width: Int,
+    columnIndex: Int,
+    compressorScores: ScoreIndicator = ScoreIndicator(0, 0, 0, 0, 0)
+) {
+  def getCompressor(
+      complementHeap: Seq[Seq[Boolean]] = null
+  ): CompressorGenerator =
+    bitheap.getCompressor(
+      compressorName,
+      width,
+      complementHeap
+    )
 
   def vivadoUtilEstimation = getCompressor().vivadoUtilEstimation
 }

--- a/src/main/scala/Chainsaw/arithmetic/bitheap/package.scala
+++ b/src/main/scala/Chainsaw/arithmetic/bitheap/package.scala
@@ -1,20 +1,110 @@
 package Chainsaw.arithmetic
 
-import Chainsaw.StringUtil
+import Chainsaw._
 
+import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 package object bitheap {
 
   val candidateCompressors = RowAdders() ++ Gpcs()
+  val solverSet = mutable.Set[BitHeapSolver](
+    NaiveSolver,
+    GreedSolver,
+    StrategySeparationSolver,
+    StrategySeparationOptimizedSolver,
+    TernaryTreeSolver,
+    GpcSolver
+  )
 
-  def getCompressor(compressorName: String, width: Int = -1, complementHeap: Seq[Seq[Boolean]] = null): CompressorGenerator = {
-    compressorName match {
+  def getCompressor(
+      compressorName: String,
+      width: Int                        = -1,
+      complementHeap: Seq[Seq[Boolean]] = null
+  ): CompressorGenerator = {
+    compressorName.firstBeforeChar('_') match {
       case "Compressor1to1" => Compressor1to1(width, complementHeap)
       case "Compressor3to2" => Compressor3to2(complementHeap)
       case "Compressor6to3" => Compressor6to3(complementHeap)
       case "Compressor3to1" => Compressor3to1(width, 0, complementHeap)
       case "Compressor4to2" => Compressor4to2(width, complementHeap)
     }
+  }
+
+  def searchBestSolver(
+      bitHeapGroup: BitHeapGroup[BigInt],
+      compressionStrategy: CompressionStrategy = ReFirst,
+      detailReport: Boolean                    = false
+  ): CompressorFullSolution = {
+    val solverSolutions       = solverSet.toSeq.map(solver => (solver, solver.solveAll(bitHeapGroup.copy)))
+    var target                = ""
+    var result: BitHeapSolver = NaiveSolver
+
+    compressionStrategy match {
+      case BrFirst =>
+        target = "maximize bit reduction"
+        result = solverSolutions
+          .map { case (solver, solution) =>
+            (solver, solution.scores.getOrElse("br", 0.0))
+          }
+          .maxBy(_._2)
+          ._1
+      case ReFirst =>
+        target = "maximize reduction efficiency"
+        result = solverSolutions
+          .map { case (solver, solution) =>
+            (solver, solution.scores.getOrElse("re", 0.0))
+          }
+          .maxBy(_._2)
+          ._1
+      case HrFirst =>
+        target = "maximize heightReduction efficiency"
+        result = solverSolutions
+          .map { case (solver, solution) =>
+            (solver, solution.scores.getOrElse("hr", 0.0))
+          }
+          .minBy(_._2)
+          ._1
+      case RrFirst =>
+        target = "maximize reduction ratio"
+        result = solverSolutions
+          .map { case (solver, solution) =>
+            (solver, solution.scores.getOrElse("rr", 0.0))
+          }
+          .maxBy(_._2)
+          ._1
+      case MinCost =>
+        target = "minimize cost"
+        result = solverSolutions
+          .map { case (solver, solution) =>
+            (solver, solution.scores.getOrElse("cost", 0.0))
+          }
+          .minBy(_._2)
+          ._1
+    }
+
+    if (detailReport) {
+      val header = s"------------BitHeapSolver Search summary------------\n"
+      val configInfo =
+        s"\n1.Configuration information of Search:\n\n" + s"Candidate Solver: ${solverSet.toSeq
+          .map(_.solverName)
+          .mkString(",")}\n\n" + s"target: $target\n"
+      val searchResult = s"\n2.Search result(The best Solver) is :$result\n"
+      val body = s"\n3.Search report are as follows:\n\n" + solverSolutions
+        .map { case (solver, solution) =>
+          s"${solver.solverName}:\n$solution\n"
+        }
+        .mkString("\n")
+      logger.info(
+        s"$header$configInfo$searchResult$body"
+      )
+    } else {
+      logger.info(s"BitHeapSolver Search result is: $result\n")
+    }
+
+    solverSolutions
+      .find(_._1.solverName == result.solverName)
+      .getOrElse(solverSolutions.head)
+      ._2
   }
 }

--- a/src/main/scala/Chainsaw/package.scala
+++ b/src/main/scala/Chainsaw/package.scala
@@ -83,6 +83,8 @@ package object Chainsaw {
   var testFlopoco = false
   var testVhdl    = false
 
+  var testCaseIndex = 0
+
   // TODO: better dots
   val positiveDot   = "+"
   val complementDot = "-"
@@ -152,6 +154,8 @@ package object Chainsaw {
       s.reverse.padTo(len, elem).reverse
 
     def repeat(times: Int) = Seq.fill(times)(s).reduce(_ + _)
+
+    def firstBeforeChar(char: Char): String = s.split(char).head
   }
 
   implicit class seqUtil[T: ClassTag](seq: Seq[T]) {

--- a/src/main/scala/Chainsaw/xilinx/VivadoUtil.scala
+++ b/src/main/scala/Chainsaw/xilinx/VivadoUtil.scala
@@ -57,12 +57,12 @@ case class VivadoUtil(
   def >=(that: VivadoUtil): Boolean = that <= this
 
   // regard resources in CLB as one
-  def clbCost(considerFF: Boolean): Double = {
+  def clbCost(isPipeline: Boolean): Double = {
     val considerTable = Seq(lut, carry8 * 8, ff / 2)
     if (considerTable.forall(_ == 0.0))
       throw new IllegalArgumentException("no estimation exist!")
     // TODO: /8 for clb?
-    if (considerFF) considerTable.max else considerTable.init.max
+    if (isPipeline) considerTable.max else considerTable.init.max
   }
 
   override def toString = {
@@ -95,9 +95,7 @@ case class VivadoUtil(
       }
 
     val weights =
-      solveVars.map(i =>
-        schemes.map(scheme => scheme.getValues(i).toInt).toArray
-      )
+      solveVars.map(i => schemes.map(scheme => scheme.getValues(i).toInt).toArray)
     val budgets = solveVars.map(i => this.getValues(i))
 
     val variables: Array[IloIntVar] =

--- a/src/test/scala/Chainsaw/ChainsawFlatSpec.scala
+++ b/src/test/scala/Chainsaw/ChainsawFlatSpec.scala
@@ -61,7 +61,7 @@ abstract class ChainsawFlatSpec extends AnyFlatSpec {
     behavior of gen.name
 
     if (full) {
-      it should "work correctly" in {
+      it should s"work correctly on testCase$testCaseIndex" in {
         ChainsawSimBox(testConfig.naiveList) {
           gen.doSelfTest()
         }
@@ -69,7 +69,7 @@ abstract class ChainsawFlatSpec extends AnyFlatSpec {
     }
 
     if (naive) {
-      it should "has a correct naive implementation" in {
+      it should s"has a correct naive implementation on testCase$testCaseIndex" in {
         gen.setAsNaive()
         assert(gen.useNaive)
         gen.doSelfTest()
@@ -78,14 +78,15 @@ abstract class ChainsawFlatSpec extends AnyFlatSpec {
     }
 
     if (synth && allowSynth) { // when impl is set, synth is not necessary
-      it should "meet the util & fmax requirement after synth" in
+      it should s"meet the util & fmax requirement after synth on testCase$testCaseIndex" in
         ChainsawSynth(gen, testConfig.utilRequirementStrategy)
     }
 
     if (impl && allowImpl) {
-      it should "meet the util & fmax requirement after impl" in
+      it should s"meet the util & fmax requirement after impl on testCase$testCaseIndex" in
         ChainsawImpl(gen, testConfig.utilRequirementStrategy)
     }
+    testCaseIndex += 1
   }
 
   def testFlopocoOperator(

--- a/src/test/scala/Chainsaw/arithmetic/ArithmeticIpTests.scala
+++ b/src/test/scala/Chainsaw/arithmetic/ArithmeticIpTests.scala
@@ -123,6 +123,7 @@ class ArithmeticIpTests extends ChainsawFlatSpec {
                   widthOut = widthIn,
                   useCsd   = useCsd
                 )
+              case _ => ???
             }
             if (multType == MsbMultiplier)
               logger.info(
@@ -158,6 +159,7 @@ class ArithmeticIpTests extends ChainsawFlatSpec {
             )
           case LsbMultiplier =>
             LsbBcm(constant = constant, widthIn = widthIn, widthOut = widthIn)
+          case _ => ???
         }
         testOperator(gen, generatorConfigTable("Bcm"))
       }

--- a/src/test/scala/Chainsaw/arithmetic/bitheap/BitHeapSolverTest.scala
+++ b/src/test/scala/Chainsaw/arithmetic/bitheap/BitHeapSolverTest.scala
@@ -1,8 +1,11 @@
 package Chainsaw.arithmetic.bitheap
 
 import Chainsaw.arithmetic._
-import Chainsaw.{ChainsawFlatSpec, TestConfig, verbose}
+import Chainsaw._
 import org.apache.commons.io.FileUtils
+import ArithInfoGenerator._
+
+import java.io._
 
 class BitHeapSolverTest extends ChainsawFlatSpec {
 
@@ -16,17 +19,115 @@ class BitHeapSolverTest extends ChainsawFlatSpec {
     //    Seq.fill(9)(ArithInfo(200, 0)) ++ Seq.fill(9)(ArithInfo(200, 0, isPositive = false, time = 1)), // mixed, same time
     //    Seq.fill(5)(ArithInfo(100, 0)) ++ Seq.fill(5)(ArithInfo(100, 0, isPositive = false, time = 1)), // mixed, diff time
     //    Seq.fill(5)(ArithInfo(10, 2)) ++ Seq.fill(5)(ArithInfo(10, 1, isPositive = false, time = 1)), // mixed, diff time
-    Seq(
-      ArithInfo(64, 128),
-      ArithInfo(64, 192),
-      ArithInfo(64, 160),
-      ArithInfo(64, 160, isPositive = false),
-      ArithInfo(64, 160, isPositive = false),
-      ArithInfo(32, 192),
-      ArithInfo(32, 192),
-      ArithInfo(1, 224)
-    ) // case from Bm
-  )
+
+    RectangularInfos(
+      50 to 100 by 50,
+      50 to 100 by 50
+    ), // rectangle, positive, same time
+    RectangularInfos(
+      50 to 100 by 50,
+      50 to 100 by 50,
+      withNoise = true
+    ), // rectangle, positive, same time, withNoise
+    RectangularInfos(
+      50 to 100 by 50,
+      50 to 100 by 50,
+      withNoise    = true,
+      timeStrategy = IncreaseTimeDiff,
+      timeUpBound  = 10
+    ), // rectangle, positive, diff time(Increase), withNoise
+    RectangularInfos(
+      50 to 100 by 50,
+      50 to 100 by 50,
+      withNoise    = true,
+      timeStrategy = RandomTimeDiff,
+      timeUpBound  = 10
+    ), // rectangle, positive, diff time(Random), withNoise
+    RectangularInfos(
+      50 to 100 by 50,
+      50 to 100 by 50,
+      timeStrategy = IncreaseTimeDiff,
+      timeUpBound  = 10
+    ), // rectangle, positive, diff time(Increase)
+    RectangularInfos(
+      50 to 100 by 50,
+      50 to 100 by 50,
+      timeStrategy = RandomTimeDiff,
+      timeUpBound  = 10
+    ), // rectangle, positive, diff time(Random)
+    RectangularInfos(
+      50 to 100 by 50,
+      50 to 100 by 50,
+      randomSign = true
+    ), // rectangle, mixSign, same time
+    RectangularInfos(
+      100 to 100 by 50,
+      100 to 100 by 50,
+      withNoise  = true,
+      randomSign = true,
+      shift      = 2
+    ), // rectangle, mixSign, same time, withNoise
+    RectangularInfos(
+      100 to 100 by 50,
+      100 to 100 by 50,
+      randomSign   = true,
+      shift        = 2,
+      timeStrategy = RandomTimeDiff,
+      timeUpBound  = 10
+    ), // rectangle, mixSign, diff time
+    RectangularInfos(
+      100 to 100 by 50,
+      100 to 100 by 50,
+      withNoise    = true,
+      randomSign   = true,
+      shift        = 2,
+      timeStrategy = RandomTimeDiff,
+      timeUpBound  = 10
+    ),                                                             // rectangle, mixSign, diff time, withNoise
+    TriangleInfos(widthRange = 50 to 100 by 50),                   // triangle, positive, same time
+    TriangleInfos(widthRange = 50 to 100 by 50, withNoise = true), // triangle, positive, same time, withNoise
+    TriangleInfos(widthRange = 50 to 100 by 50, withNoise = true), // triangle, positive, same time, withNoise
+    TriangleInfos(
+      widthRange   = 50 to 100 by 50,
+      timeStrategy = RandomTimeDiff,
+      timeUpBound  = 10
+    ), // triangle, positive, diff time(Random)
+    TriangleInfos(
+      widthRange   = 50 to 100 by 50,
+      timeStrategy = RandomTimeDiff,
+      timeUpBound  = 10,
+      withNoise    = true
+    ),                                                              // triangle, positive, diff time(Random), withNoise
+    TriangleInfos(widthRange = 50 to 100 by 50, randomSign = true), // triangle, mixedSign, same time
+    TriangleInfos(
+      widthRange = 50 to 100 by 50,
+      randomSign = true,
+      withNoise  = true
+    ), // triangle, mixedSign, same time, withNoise
+    TriangleInfos(
+      widthRange   = 50 to 100 by 50,
+      randomSign   = true,
+      timeStrategy = RandomTimeDiff,
+      timeUpBound  = 10
+    ), // triangle, mixedSign, diff time
+    TriangleInfos(
+      widthRange   = 50 to 100 by 50,
+      randomSign   = true,
+      withNoise    = true,
+      timeStrategy = RandomTimeDiff,
+      timeUpBound  = 10
+    ) // triangle, mixedSign, diff time, withNoise
+//    Seq(
+//      ArithInfo(64, 128),
+//      ArithInfo(64, 192),
+//      ArithInfo(64, 160),
+//      ArithInfo(64, 160, isPositive = false),
+//      ArithInfo(64, 160, isPositive = false),
+//      ArithInfo(32, 192),
+//      ArithInfo(32, 192),
+//      ArithInfo(1, 224)
+//    ) // case from Bm
+  ).flatten.map(_._1)
 
   /** -------- 2. solver tester function
     * --------
@@ -40,16 +141,157 @@ class BitHeapSolverTest extends ChainsawFlatSpec {
     })
   }
 
+  def testNaiveSolver(): Unit = testSolver(NaiveSolver)
+
   def testGreedSolver(): Unit = testSolver(GreedSolver)
 
+  def testStrategySeparationSolver(): Unit = testSolver(
+    StrategySeparationSolver
+  )
+
+  def testStrategySeparationOptimizedSolver(): Unit = testSolver(
+    StrategySeparationOptimizedSolver
+  )
+
+  def testTernaryTreeSolver(): Unit = testSolver(TernaryTreeSolver)
+
+  def testGpcSolver(): Unit = testSolver(GpcSolver)
+
+  def testBestSolver(): Unit = testSolver(solverUnderTest = null)
+
+  def evalHeapSize(
+      widthRange: Range,
+      heightRange: Range    = Range(10, 20, 10),
+      isRectangle: Boolean  = true,
+      solver: BitHeapSolver = null
+  ) = {
+    val evalResultFile = new File(
+      s"src/main/resources/evalSizeResults",
+      s"${hashName(s"Width[${widthRange.start}:${widthRange.step}:${widthRange.end}]_Height[${heightRange.start}:${heightRange.step}:${heightRange.end}]_${if (isRectangle) "Rectangle" else "Triangle"}_${if (solver == null) "InferredSolver"
+      else s"${solver.solverName}"}")}.txt"
+    )
+    var resultString = ""
+    if (!evalResultFile.exists()) {
+      val testCases = widthRange
+        .flatMap { w =>
+          heightRange.map { h =>
+            (w, h) -> BitHeapGroup.fromInfos(
+              if (isRectangle) genRectangularInfos(w, h)
+              else genTriangleInfos(w)
+            )
+          }
+        }
+      val solutions =
+        testCases.map(testCase =>
+          testCase._1 -> (if (solver == null)
+                            searchBestSolver(testCase._2).scores
+                          else solver.solveAll(testCase._2).scores)
+        )
+
+      // eval width influence
+      val sortedSolutionByWidth =
+        solutions
+          .groupBy(_._1._2)
+          .toSeq
+          .sortBy(_._1)
+          .map { case (h, scoresWithSize) =>
+            h -> scoresWithSize.map { case (size, scores) => (size._1, scores) }
+          }
+      // eval height influence
+      val sortedSolutionByHeight =
+        solutions
+          .groupBy(_._1._1)
+          .toSeq
+          .sortBy(_._1)
+          .map { case (h, scoresWithSize) =>
+            h -> scoresWithSize.map { case (size, scores) => (size._2, scores) }
+          }
+
+      def padTarget(target: String) = target match {
+        case "br" => "bit reduction"
+        case "re" => "reduction efficiency"
+        case "rr" => "reduction ratio"
+        case "hr" => "height reduction"
+        case _    => target
+      }
+      def targetSeparator(target: String) =
+        s"\n****the comparison of ${padTarget(target)}****\n\n"
+      def targetResultByWidth(target: String) = {
+        sortedSolutionByWidth
+          .map { case (h, scoresWithWidth) =>
+            h -> scoresWithWidth
+              .map { case (w, scores) =>
+                w -> scores.getOrElse(target, 0.0)
+              }
+              .sortBy(_._2)
+          }
+          .zipWithIndex
+          .map { case ((h, scoresWithWidth), i) =>
+            val sortedWidths = scoresWithWidth.map(_._1).reverse
+            s"${i + 1}.height = $h, the comparison of ${padTarget(target)}:\n" +
+              s"${sortedWidths.mkString(">")}\n" +
+              s"best width is ${sortedWidths.head}\n" +
+              s"${if (sortedWidths.head == widthRange.max) "maybe not reach peak, can add widthMax to test"
+              else s"get a peak in ${sortedWidths.head}, where widthMax is ${widthRange.max}"}\n"
+          }
+          .mkString("\n")
+      }
+
+      def targetResultByHeight(target: String) = {
+        sortedSolutionByHeight
+          .map { case (w, scoresWithHeight) =>
+            w -> scoresWithHeight
+              .map { case (h, scores) =>
+                h -> scores.getOrElse(target, 0.0)
+              }
+              .sortBy(_._2)
+          }
+          .zipWithIndex
+          .map { case ((w, scoresWithHeight), i) =>
+            val sortedHeights = scoresWithHeight.map(_._1).reverse
+            s"${i + 1}.width = $w, the comparison of ${padTarget(target)}:\n" +
+              s"${sortedHeights.mkString(">")}\n" +
+              s"best height is ${sortedHeights.head}\n" +
+              s"${if (sortedHeights.head == heightRange.max) "maybe not reach peak, can add heightMax to test"
+              else s"get a peak in ${sortedHeights.head}, where heightMax is ${heightRange.max}"}\n"
+          }
+          .mkString("\n")
+      }
+      val header = s"Evaluate the effect of BitHeap size on compress scores\n\n"
+      val evalWidthStart =
+        s"--------the effect of BitHeap width on scores--------\n"
+      val evalHeightStart =
+        s"--------the effect of BitHeap Height on scores--------\n"
+
+      resultString = s"$header$evalWidthStart${Seq("br", "cost", "re", "rr", "hr")
+        .map(target => s"${targetSeparator(target)}${targetResultByWidth(target)}")
+        .mkString("")}\n$evalHeightStart${Seq("br", "cost", "re", "rr", "hr")
+        .map(target => s"${targetSeparator(target)}${targetResultByHeight(target)}")
+        .mkString("")}"
+
+      FileUtils.writeStringToFile(evalResultFile, resultString)
+    } else {
+      resultString = FileUtils.readFileToString(evalResultFile)
+    }
+
+    logger.info(resultString)
+
+  }
   override def generatorConfigTable = Map(
     "BitHeapCompressor" -> TestConfig(
       full  = true,
       naive = false,
-      synth = true,
+      synth = false,
       impl  = false
     )
   )
 
-  testGreedSolver()
+//  testNaiveSolver()
+//  testGreedSolver()
+//  testStrategySeparationSolver()
+//  testStrategySeparationOptimizedSolver()
+//  testTernaryTreeSolver()
+//  testGpcSolver()
+  testBestSolver()
+//  evalHeapSize(Range.inclusive(190, 300, 10), Range.inclusive(80, 100, 20), true)
 }


### PR DESCRIPTION
[ArithInfo.scala]: Improve the special situation of ArithInfo for BitHeap test
[ArithmeticIpTest.scala]: add ??? implement for match
[BitHeap.scala]: Fixed known problems during testing
[BitHeapCompressor.scala]: Modify the use of the solver and solution according to the change of other code
[BitHeapGroup.scala]: Add some attribute for solver and fix some code
[BitHeapSolver.scala]: 
1) add some attribute to BitHeapSolver for defining solve strategy
2) add some solver strategy:  StrategySeparationSolver, StrategySeparationOptimizedSolver, TernaryTreeSolver, GpcSolver
[BitHeapSolverTest.scala]: 
1) Complete the test set
2) add a method named evalHeapSize for evaluating scores in different size
[BitHeapTests.scala]: Modify some code according to the change of other code
[ChainsawBaseGenerator.scala]: add require for FrameGenerator
[ChainsawFlatSpec.scala]: fix the testOperator testName duplicate error when testCase number more than one
[Compressor.scala]: add a attribute about pipeline for removing the pipeline parameter  of some method
[CompressorSolution.scala]: add cost attribute to ScoreIndicator and add a scores method for reporting solution
[Enums.scala]: add some CompressionStrategy for testCase generator
[bitheap.package.scala]: add a searchBestSolver for solve a best Solver for a specific BitHeap
[chainsaw.package.scala]: add testCaseIndex for testOperator and a StringUtil method
[RowAdders.scala]: 
1) improve the impH method of Compressor4to2 to support Complement bit
2) improve the cost evaluate of Compressor3to1
[VivadoUtil.scala]: remove the isPipeline parameter of clbCost method